### PR TITLE
updated typing with https policy for missing bearer apis

### DIFF
--- a/platform_api_client/api/external_api.py
+++ b/platform_api_client/api/external_api.py
@@ -3234,6 +3234,7 @@ class EXTERNALApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'HTTPBearer'
         ]
 
         return self.api_client.param_serialize(
@@ -3991,6 +3992,7 @@ class EXTERNALApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'HTTPBearer'
         ]
 
         return self.api_client.param_serialize(

--- a/platform_api_client/models/endpoint_ready_state.py
+++ b/platform_api_client/models/endpoint_ready_state.py
@@ -37,6 +37,8 @@ class EndpointReadyState(str, Enum):
     CONTAINER_MISSING = 'CONTAINER_MISSING'
     PROGRESS_DEADLINE_EXCEEDED = 'PROGRESS_DEADLINE_EXCEEDED'
     REVISION_MISSING = 'REVISION_MISSING'
+    COMPLETE = 'COMPLETE'
+    FAILED_JOB = 'FAILED_JOB'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:


### PR DESCRIPTION
- updated typing with https policy for missing bearer for hardware instances and prebuild images api

## Related PR
https://github.com/CentML/platform/pull/816